### PR TITLE
Adds some padding to CDB-Shape-threePoints so that is easier to click on the button

### DIFF
--- a/src/scss/cdb-components/shapes/threePoints.scss
+++ b/src/scss/cdb-components/shapes/threePoints.scss
@@ -106,9 +106,11 @@ Description
 
 .CDB-Shape-threePoints {
   display: inline-block;
+  padding: 0 4px;
 }
 .CDB-Shape-threePoints.is-horizontal {
   transform: rotate(90deg);
+  padding: 4px 0;
 }
 
 .CDB-Shape-threePointsItem {


### PR DESCRIPTION
Buttons are now 10px wide (or tall if the component `.is-horizontal`).

![screen shot 2016-05-17 at 11 31 48](https://cloud.githubusercontent.com/assets/390398/15318365/0f04f194-1c26-11e6-81d8-77abcbb24197.png)

NOTE: Red outline in ☝️ is not present in the new CSS. It's only there so that you can see how tall/wide the component will be.

@piensaenpixel anything to say about this? thx!
