### PR TITLE
Replaced `CDB-OptionInput-item:after` content character

### DIFF
--- a/src/scss/cdb-components/forms/option-input.scss
+++ b/src/scss/cdb-components/forms/option-input.scss
@@ -123,7 +123,7 @@
     width: 1px;
     height: 1px;
     margin: 0 $baseSize - 2;
-    background-color: $cHintText;
+    background-color: $cSecondaryLine;
     content: '';
   }
   &:last-child {

--- a/src/scss/cdb-components/forms/option-input.scss
+++ b/src/scss/cdb-components/forms/option-input.scss
@@ -120,9 +120,11 @@
   box-sizing: content-box;
 
   &::after {
-    padding: 0 $baseSize - 2;
-    color: $cHintText;
-    content: '·';
+    margin: 0 $baseSize - 2;
+    background-color: $cHintText;
+    content: '';
+    width: 1px;
+    height: 1px;
   }
   &:last-child {
     width: 100%;

--- a/src/scss/cdb-components/forms/option-input.scss
+++ b/src/scss/cdb-components/forms/option-input.scss
@@ -120,11 +120,11 @@
   box-sizing: content-box;
 
   &::after {
+    width: 1px;
+    height: 1px;
     margin: 0 $baseSize - 2;
     background-color: $cHintText;
     content: '';
-    width: 1px;
-    height: 1px;
   }
   &:last-child {
     width: 100%;


### PR DESCRIPTION
Fixes #148 

Used dimensions and background color to take the same result without character in the content, avoiding characters problems.
- Before:
  <img width="497" alt="screen shot 2016-09-22 at 16 24 34" src="https://cloud.githubusercontent.com/assets/2141690/18751960/2f6df5c8-80e1-11e6-8f77-8eaca5d892ea.png">
- After:
  <img width="485" alt="screen shot 2016-09-22 at 16 24 15" src="https://cloud.githubusercontent.com/assets/2141690/18751942/23d9a590-80e1-11e6-8d85-a05114251cb4.png">

CR @piensaenpixel 
