### PR TITLE
reorder cdb-utilities/helpers in entry.scss

### DIFF
--- a/src/scss/cdb-components/_loader.scss
+++ b/src/scss/cdb-components/_loader.scss
@@ -117,6 +117,7 @@ This is the generic loader for widgets, maps, components, ...
   height: 14px;
 }
 
+.CDB-LoaderIcon--big,
 .CDB-LoaderIcon--big .CDB-LoaderIcon-spinner {
   width: 40px;
   height: 40px;

--- a/src/scss/cdb-components/_loader.scss
+++ b/src/scss/cdb-components/_loader.scss
@@ -117,7 +117,6 @@ This is the generic loader for widgets, maps, components, ...
   height: 14px;
 }
 
-.CDB-LoaderIcon--big,
 .CDB-LoaderIcon--big .CDB-LoaderIcon-spinner {
   width: 40px;
   height: 40px;

--- a/src/scss/cdb-utilities/_helpers.scss
+++ b/src/scss/cdb-utilities/_helpers.scss
@@ -92,7 +92,7 @@
 
 /* Flex */
 .u-flex {
-  @include display-flex();
+  @include display-flex(true);
 }
 .u-justifySpace {
   @include justify-content(space-between);

--- a/src/scss/cdb-utilities/_helpers.scss
+++ b/src/scss/cdb-utilities/_helpers.scss
@@ -126,10 +126,3 @@
     display: block !important;
   }
 }
-
-/* helper mixins */
-@mixin default-form-error-style() {
-  border: 1px solid rgba($cError, 0.48);
-  background: rgba($cError, 0.04);
-  color: $cError;
-}

--- a/src/scss/cdb-utilities/_mixins.scss
+++ b/src/scss/cdb-utilities/_mixins.scss
@@ -234,3 +234,9 @@
     @content;
   }
 }
+
+@mixin default-form-error-style() {
+  border: 1px solid rgba($cError, 0.48);
+  background: rgba($cError, 0.04);
+  color: $cError;
+}

--- a/src/scss/cdb-utilities/_mixins.scss
+++ b/src/scss/cdb-utilities/_mixins.scss
@@ -25,12 +25,20 @@
 }
 
 // Display flex functions
-@mixin display-flex() {
-  display: -webkit-box;      /* OLD - iOS 6-, Safari 3.1-6 */
-  display: -moz-box;         /* OLD - Firefox 19- (buggy but mostly works) */
-  display: -ms-flexbox;      /* TWEENER - IE 10 */
-  display: -webkit-flex;     /* NEW - Chrome */
-  display: flex;             /* NEW, Spec - Opera 12.1, Firefox 20+ */
+@mixin display-flex($is_imp: false) {
+  @if $is_imp == true {
+    display: -webkit-box !important;      /* OLD - iOS 6-, Safari 3.1-6 */
+    display: -moz-box !important;         /* OLD - Firefox 19- (buggy but mostly works) */
+    display: -ms-flexbox !important;      /* TWEENER - IE 10 */
+    display: -webkit-flex !important;     /* NEW - Chrome */
+    display: flex !important;             /* NEW, Spec - Opera 12.1, Firefox 20+ */
+  } @else {
+    display: -webkit-box;      /* OLD - iOS 6-, Safari 3.1-6 */
+    display: -moz-box;         /* OLD - Firefox 19- (buggy but mostly works) */
+    display: -ms-flexbox;      /* TWEENER - IE 10 */
+    display: -webkit-flex;     /* NEW - Chrome */
+    display: flex;             /* NEW, Spec - Opera 12.1, Firefox 20+ */
+  }
 }
 @mixin flex($v) {
   -webkit-box-flex: $v;

--- a/src/scss/entry.scss
+++ b/src/scss/entry.scss
@@ -6,6 +6,8 @@
 @import 'cdb-variables/colors';
 @import 'cdb-utilities/mixins';
 
+@import 'cdb-icon-font';
+
 @import 'cdb-utilities/vendor/reset';
 @import 'cdb-utilities/vendor/normalize';
 @import 'cdb-utilities/defaults';
@@ -52,5 +54,3 @@
 @import 'cdb-components/tags';
 @import 'cdb-components/tooltips';
 @import 'cdb-components/typography';
-
-@import 'cdb-icon-font';

--- a/src/scss/entry.scss
+++ b/src/scss/entry.scss
@@ -10,6 +10,7 @@
 @import 'cdb-utilities/vendor/normalize';
 @import 'cdb-utilities/defaults';
 @import 'cdb-utilities/fonts';
+@import 'cdb-utilities/helpers';
 
 @import 'vendor/perfect-scrollbar/main'; // Perfect scrollbar styles
 
@@ -53,4 +54,3 @@
 @import 'cdb-components/typography';
 
 @import 'cdb-icon-font';
-@import 'cdb-utilities/helpers';

--- a/src/scss/entry.scss
+++ b/src/scss/entry.scss
@@ -6,13 +6,10 @@
 @import 'cdb-variables/colors';
 @import 'cdb-utilities/mixins';
 
-@import 'cdb-icon-font';
-
 @import 'cdb-utilities/vendor/reset';
 @import 'cdb-utilities/vendor/normalize';
 @import 'cdb-utilities/defaults';
 @import 'cdb-utilities/fonts';
-@import 'cdb-utilities/helpers';
 
 @import 'vendor/perfect-scrollbar/main'; // Perfect scrollbar styles
 
@@ -54,3 +51,6 @@
 @import 'cdb-components/tags';
 @import 'cdb-components/tooltips';
 @import 'cdb-components/typography';
+
+@import 'cdb-icon-font';
+@import 'cdb-utilities/helpers';


### PR DESCRIPTION
Issue: https://github.com/CartoDB/cartodb/issues/12227
PR in CartoDB: https://github.com/CartoDB/cartodb/pull/12234

Because of the file order in `entry.scss` we were overriding the `u-flex` class which lead to some icons not displaying properly.

@xavijam @piensaenpixel