### PR TITLE
move layerselector from builder to cartoassets

### DIFF
--- a/src/scss/cdb-components/_layer-selector.scss
+++ b/src/scss/cdb-components/_layer-selector.scss
@@ -1,0 +1,23 @@
+// Layer selector and letters
+// ----------------------------------------------
+
+/* SG
+# Layer selector and letters
+
+
+```
+  <span class="CDB-SelectorLayer-letter CDB-Text CDB-Size-small u-whiteTextColor u-rSpace u-upperCase" style="background-color: #E65176">b0</span>
+```
+*/
+
+.CDB-SelectorLayer {
+  position: relative;
+}
+.CDB-SelectorLayer.is-disabled {
+  background-color: $cThirdBackground;
+}
+.CDB-SelectorLayer-letter {
+  height: 14px;
+  padding: 1px 5px;
+  border-radius: 2px;
+}

--- a/src/scss/entry.scss
+++ b/src/scss/entry.scss
@@ -52,5 +52,6 @@
 @import 'cdb-components/tags';
 @import 'cdb-components/tooltips';
 @import 'cdb-components/typography';
+@import 'cdb-components/layer-selector';
 
 @import 'cdb-icon-font';


### PR DESCRIPTION
re: https://github.com/CartoDB/cartodb/issues/9956

moved the layer selector from Builder to a more general component here, to be used in deep-insights, as well

![screen shot 2017-06-21 at 14 51 55](https://user-images.githubusercontent.com/36676/27384977-432300a0-5691-11e7-9302-34dc7fb2460d.png)


(small square with the source id inside)