### PR TITLE
Fix global blue

### DIFF
--- a/src/scss/cdb-variables/_colors.scss
+++ b/src/scss/cdb-variables/_colors.scss
@@ -2,7 +2,7 @@
 // ----------------------------------------------
 
 // General
-$cBlue: #1181FB;
+$cBlue: #1785FB;
 $cBlack: #000;
 $cWhite: #FFF;
 $cMainBg: #2E3C43;


### PR DESCRIPTION
Related to: https://github.com/CartoDB/cartodb/issues/12479

Update global `$cBlue` variable to `#1785FB`