### PR TITLE
Override default border-radius button

### DIFF
--- a/src/scss/cdb-components/_menu.scss
+++ b/src/scss/cdb-components/_menu.scss
@@ -150,6 +150,7 @@
   margin-bottom: -1px;
   padding: 4px 0 11px;
   border-bottom: 1px solid transparent;
+  border-radius: 0;
   color: $cBlue;
 }
 


### PR DESCRIPTION
Related to: https://github.com/CartoDB/CartoAssets/issues/172 and https://github.com/CartoDB/cartodb/issues/12978

Google changed the default `border-radius` (among other things) in Google Chrome for Mac, so the navigation tabs look weird.