### PR TITLE
Add is-disabled state to CDB-Submenu-item

### DIFF
--- a/src/scss/cdb-components/_menu.scss
+++ b/src/scss/cdb-components/_menu.scss
@@ -201,6 +201,12 @@
   color: $cMainText;
 }
 
+.CDB-NavSubmenu-item.is-disabled .CDB-NavSubmenu-link {
+  pointer-events: none;
+  color: $cHintText;
+  cursor: default;
+}
+
 .CDB-NavSubmenu-status {
   margin-left: 2px;
 }


### PR DESCRIPTION
* Same as https://github.com/CartoDB/CartoAssets/pull/175 but for submenu items. 
* Useful for https://github.com/CartoDB/cartodb/issues/12728