### PR TITLE
Load carto icon font after fonts

### DIFF
--- a/src/scss/entry.scss
+++ b/src/scss/entry.scss
@@ -10,6 +10,7 @@
 @import 'cdb-utilities/vendor/normalize';
 @import 'cdb-utilities/defaults';
 @import 'cdb-utilities/fonts';
+@import 'cdb-icon-font';
 @import 'cdb-utilities/helpers';
 
 @import 'vendor/perfect-scrollbar/main'; // Perfect scrollbar styles
@@ -53,5 +54,3 @@
 @import 'cdb-components/tooltips';
 @import 'cdb-components/typography';
 @import 'cdb-components/layer-selector';
-
-@import 'cdb-icon-font';


### PR DESCRIPTION
Related to: https://github.com/CartoDB/cartodb/pull/13239#issuecomment-352463614

Basically, it was loading at the end, so when using utility classes like `CDB-Size-small` the line height wasn't applied, since it just loads a font I think we could move it to the top.