### PR TITLE
Fix font icon require order

### DIFF
--- a/src/scss/entry.scss
+++ b/src/scss/entry.scss
@@ -10,7 +10,6 @@
 @import 'cdb-utilities/vendor/normalize';
 @import 'cdb-utilities/defaults';
 @import 'cdb-utilities/fonts';
-@import 'cdb-icon-font';
 @import 'cdb-utilities/helpers';
 
 @import 'vendor/perfect-scrollbar/main'; // Perfect scrollbar styles
@@ -53,4 +52,5 @@
 @import 'cdb-components/tags';
 @import 'cdb-components/tooltips';
 @import 'cdb-components/typography';
+@import 'cdb-icon-font';
 @import 'cdb-components/layer-selector';


### PR DESCRIPTION
It has to go below typography because we're using `CDB-Text`
in some font icons, which overrides the `font-family` and breaks the icon