### PR TITLE
Nothing else should be interactive when a dropdown is open

### DIFF
--- a/src/scss/cdb-components/_boxes.scss
+++ b/src/scss/cdb-components/_boxes.scss
@@ -36,3 +36,11 @@
 .CDB-Box-modalHeaderItem--paddingVertical {
   padding: $baseSize + 4 0;
 }
+.CDB-Box-modalOverlay {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 99;
+}


### PR DESCRIPTION
This PR adds the `.CDB-Box-modalOverlay` class to _boxes.scss, needed to apply styles to dropdown's overlay. Coming from https://github.com/CartoDB/cartodb/pull/13283.