### PR TITLE
Add disabled state to NavSubmenu-item

### DIFF
--- a/src/scss/cdb-components/_menu.scss
+++ b/src/scss/cdb-components/_menu.scss
@@ -214,9 +214,17 @@
 }
 
 
-.CDB-NavSubmenu-item.is-selected .CDB-NavSubmenu-link {
-  border-bottom: 2px solid $cMainLine;
-  color: $cMainText;
+.CDB-NavSubmenu-item {
+  &.is-selected .CDB-NavSubmenu-link {
+    border-bottom: 2px solid $cMainLine;
+    color: $cMainText;
+  }
+
+  &.is-disabled .CDB-NavSubmenu-link {
+    pointer-events: none;
+    color: $cHintText;
+    cursor: default;
+  }
 }
 
 .CDB-NavSubmenu-status {


### PR DESCRIPTION
With the last changes in https://github.com/CartoDB/cartodb/pull/13324 we are disabling a submenu tab, this PR adds that state to the`NavSubmenu-item` styles.