### PR TITLE
Fix CDB-NavSubmenu-item border bottom and selected color

### DIFF
--- a/src/scss/cdb-components/_menu.scss
+++ b/src/scss/cdb-components/_menu.scss
@@ -184,7 +184,7 @@
 }
 
 .CDB-NavSubmenu {
-  border-bottom: 2px solid $cSecondaryLine;
+  border-bottom: 1px solid $cSecondaryLine;
 
   &--inside {
     position: absolute;
@@ -216,7 +216,7 @@
 
 .CDB-NavSubmenu-item {
   &.is-selected .CDB-NavSubmenu-link {
-    border-bottom: 2px solid $cMainLine;
+    border-bottom: 2px solid $cMainText;
     color: $cMainText;
   }
 


### PR DESCRIPTION
Related to: https://github.com/CartoDB/cartodb/issues/13340 and https://github.com/CartoDB/cartodb/issues/13337

![screen shot 2018-01-10 at 09 05 31](https://user-images.githubusercontent.com/905225/34761782-7524d148-f5e5-11e7-9ff9-4812affb1091.png)
