### PR TITLE
Better color for disabled & checked checkbox

### DIFF
--- a/src/scss/cdb-components/forms/_checkbox.scss
+++ b/src/scss/cdb-components/forms/_checkbox.scss
@@ -118,7 +118,7 @@
 
   &::before,
   &::after {
-    opacity: 1;
     background: $cAltText;
+    opacity: 1;
   }
 }

--- a/src/scss/cdb-components/forms/_checkbox.scss
+++ b/src/scss/cdb-components/forms/_checkbox.scss
@@ -111,3 +111,14 @@
     opacity: 0;
   }
 }
+
+.CDB-Checkbox:checked:disabled + .CDB-Checkbox-face {
+  border: 1px solid $cSecondaryLine;
+  background: $cThirdBackground;
+
+  &::before,
+  &::after {
+    opacity: 1;
+    background: $cAltText;
+  }
+}


### PR DESCRIPTION
The `:disabled` attribute was setting `opactity: 0` to the check mark even if the checkbox was checked, this PR sets the opacity to 1 for that case and also changes the color for the check mark.

Before:
![screen shot 2018-02-08 at 10 49 39](https://user-images.githubusercontent.com/905225/35966323-cb7e88ec-0cbd-11e8-88e3-d355b1c71750.png)

After:
![screen shot 2018-02-08 at 10 50 04](https://user-images.githubusercontent.com/905225/35966337-d62bca0c-0cbd-11e8-9464-c23780975b20.png)
