### PR TITLE
Use fixed height in option-input border

### DIFF
--- a/src/scss/cdb-components/forms/_option-input.scss
+++ b/src/scss/cdb-components/forms/_option-input.scss
@@ -181,7 +181,7 @@
       position: absolute;
       left: -1px;
       width: 1px;
-      height: calc(100% + 2px);
+      height: 32px;
       content: '';
     }
 

--- a/src/scss/cdb-components/forms/_option-input.scss
+++ b/src/scss/cdb-components/forms/_option-input.scss
@@ -181,7 +181,7 @@
       position: absolute;
       left: -1px;
       width: 1px;
-      height: 32px;
+      height: $baseSize * 4;
       content: '';
     }
 


### PR DESCRIPTION
This PR fixes: https://github.com/CartoDB/onpremises/issues/516

It uses a fixed value to avoid problems in IE11