### PR TITLE
Fix border position

### DIFF
--- a/src/scss/cdb-components/forms/_option-input.scss
+++ b/src/scss/cdb-components/forms/_option-input.scss
@@ -179,6 +179,7 @@
     &:focus::after,
     &:hover::after {
       position: absolute;
+      top: -1px;
       left: -1px;
       width: 1px;
       height: $baseSize * 4;


### PR DESCRIPTION
The changes introduced in https://github.com/CartoDB/CartoAssets/pull/194 didn't fully fix the problem since we needed to align the border to the top.