### PR TITLE
Fix loading circle in IE11

### DIFF
--- a/src/scss/cdb-components/_loader.scss
+++ b/src/scss/cdb-components/_loader.scss
@@ -126,7 +126,7 @@ This is the generic loader for widgets, maps, components, ...
 .CDB-LoaderIcon-path {
   stroke: rgba(255, 255, 255, 0.88);
   stroke-linecap: round;
-  stroke-dasharray: 1, 150;
+  stroke-dasharray: 90, 150;
   stroke-dashoffset: 0;
   animation: dash 1.5s ease-in-out infinite;
   stroke-width: 4px;

--- a/src/scss/cdb-components/_loader.scss
+++ b/src/scss/cdb-components/_loader.scss
@@ -126,6 +126,8 @@ This is the generic loader for widgets, maps, components, ...
 .CDB-LoaderIcon-path {
   stroke: rgba(255, 255, 255, 0.88);
   stroke-linecap: round;
+  stroke-dasharray: 1, 150;
+  stroke-dashoffset: 0;
   animation: dash 1.5s ease-in-out infinite;
   stroke-width: 4px;
 }
@@ -137,11 +139,16 @@ This is the generic loader for widgets, maps, components, ...
 .CDB-LoaderIcon.is-dark .CDB-LoaderIcon-path {
   stroke: rgba(0, 0, 0, 0.24);
 }
+
 .CDB-LoaderIcon.is-blue .CDB-LoaderIcon-path {
   stroke: $cBlue;
 }
 
 @keyframes rotate {
+  0% {
+    transform: rotate(0deg);
+  }
+
   100% {
     transform: rotate(360deg);
   }


### PR DESCRIPTION
Fixes https://github.com/CartoDB/onpremises/issues/500

Stroke animation does not work very well in some versions of IE11. By setting default stroke values for `<circle>` elements, we fix the issue of not having the loading button animated.

![loading_button](https://user-images.githubusercontent.com/3824953/37789578-93ada868-2e04-11e8-9411-165f0eca743a.gif)

