### PR TITLE
Disable pointer events in disabled buttons

### DIFF
--- a/src/scss/cdb-components/_buttons.scss
+++ b/src/scss/cdb-components/_buttons.scss
@@ -175,7 +175,10 @@ Layout Component:
   &.is-disabled {
     opacity: 0.24;
     cursor: default;
-    pointer-events: none;
+
+    &:active {
+      pointer-events: none;
+    }
   }
 }
 

--- a/src/scss/cdb-components/_buttons.scss
+++ b/src/scss/cdb-components/_buttons.scss
@@ -175,6 +175,7 @@ Layout Component:
   &.is-disabled {
     opacity: 0.24;
     cursor: default;
+    pointer-events: none;
   }
 }
 


### PR DESCRIPTION
This PR disables `pointer-events` for disabled buttons, preventing the click event from happening.

### Acceptance

Follow steps in https://github.com/CartoDB/cartodb/issues/12051