### PR TITLE
Add Clearfix class

### DIFF
--- a/src/scss/cdb-utilities/_helpers.scss
+++ b/src/scss/cdb-utilities/_helpers.scss
@@ -131,9 +131,9 @@
 
 /* Clearfix */
 .u-clearfix::after {
-  content: "";
   display: table;
   clear: both;
+  content: '';
 }
 
 

--- a/src/scss/cdb-utilities/_helpers.scss
+++ b/src/scss/cdb-utilities/_helpers.scss
@@ -129,6 +129,13 @@
   @include align-items(flex-end);
 }
 
+/* Clearfix */
+.u-clearfix::after {
+  content: "";
+  display: table;
+  clear: both;
+}
+
 
 /* Media queries*/
 @include media-query-mobile() {


### PR DESCRIPTION
This Clearfix class is needed for Carto.JS Bubble legend to work. As it is using `position: absolute`, we need clearfix to let the element take as much space as needed.

Related to https://github.com/CartoDB/support/issues/1566